### PR TITLE
Unicode

### DIFF
--- a/common/string_helpers_test.cpp
+++ b/common/string_helpers_test.cpp
@@ -30,7 +30,7 @@ TEST(UnescapeStringLiteral, Valid) {
   EXPECT_THAT(UnescapeStringLiteral("\\x12"), Optional(Eq("\x12")));
   EXPECT_THAT(UnescapeStringLiteral("test", 1), Optional(Eq("test")));
   EXPECT_THAT(UnescapeStringLiteral("test\\#n", 1), Optional(Eq("test\n")));
-  EXPECT_THAT(UnescapeStringLiteral("r\\u{E9}al\\u{2764}\\u{FE0F}\\u{1F50A}!"), Optional(Eq("réal❤️🔊!")));
+  EXPECT_THAT(UnescapeStringLiteral("r\\u{E9}al\\u{2764}\\u{FE0F}\\u{1F50A}!"), Optional(Eq("réal❤️🔊!\u{1F061}")));
 }
 
 TEST(UnescapeStringLiteral, Invalid) {

--- a/explorer/testdata/string/unicode.carbon
+++ b/explorer/testdata/string/unicode.carbon
@@ -1,0 +1,23 @@
+// Part of the Carbon Language project, under the Apache License v2.0 with LLVM
+// Exceptions. See /LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// RUN: %{explorer} %s 2>&1 | \
+// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes=false %s
+// RUN: %{explorer} --parser_debug --trace_file=- %s 2>&1 | \
+// RUN:   %{FileCheck} --match-full-lines --allow-unused-prefixes %s
+// AUTOUPDATE: %{explorer} %s
+// CHECK: result: 0
+
+package ExplorerTest api;
+
+fn CompareStr(s: String) -> i32 {
+  if (s == "str;\u{1F601}") {
+    return 0;
+  }
+  return 1;
+}
+
+fn Main() -> i32 {
+  return CompareStr("str\u0048\u0045\u004C\u004C\u004F \u0057\u004F\u0052\u004C\u0044\u0021\u{1F601}");
+}


### PR DESCRIPTION
Based on the code in `string_helpers.cpp` and `string_helpers.cpp`, I have added relevant test cases to the /explorer/testdata/string directory.

Test file `unicode.carbon` has the program to test this.